### PR TITLE
Bug fix for xslts with spaces in the name

### DIFF
--- a/includes/spreadsheet_batch_ingest.inc
+++ b/includes/spreadsheet_batch_ingest.inc
@@ -366,7 +366,7 @@ class IslandoraSpreadsheetIngestBatchObject extends IslandoraBatchObject {
     $param_string = implode(' ', $this->xsltParameters);
     $command = variable_get('islandora_spreadsheet_ingest_saxon_command', '/usr/bin/saxonb-xslt');
     $xsl_path = drupal_realpath($template_uri);
-    $process = proc_open("$command -versionmsg:off -ext:on -it:root $xsl_path $param_string",
+    $process = proc_open("$command -versionmsg:off -ext:on -it:root '$xsl_path' $param_string",
       array(
         // STDIN; not used.
         0 => array(


### PR DESCRIPTION
Use case where user uploads and XSLT template the that has a space in its name. Example "sample template.xsl"

This create a bad key pair error within saxon.
"/usr/bin/saxonb-xslt -versionmsg:off -ext:on -it:root /var/www/drupal7/sites/default/files/sample template.xsl 'label=Volume C page 77'"