### PR TITLE
Islandora Plupload creates a PDOException error

### DIFF
--- a/includes/batch.form.inc
+++ b/includes/batch.form.inc
@@ -27,6 +27,7 @@ function islandora_spreadsheet_ingest_batch_form($form, &$form_state) {
     '#title' => t('CSV File'),
     '#required' => TRUE,
     '#description' => t('Select a CSV file to upload, delimited using the below-configured delimiters.'),
+    '#islandora_plupload_do_not_alter' => TRUE,
     '#upload_location' => file_default_scheme() . '://',
     '#upload_validators' => array(
       'file_validate_extensions' => array('csv'),


### PR DESCRIPTION
## Steps to reproduce
1. Click "Add files"
2. Select the csv
3. Click "Start upload" (the file is uploaded to the server with a temporary name and entered in the database)
4. Select a template and datastreams
5. Enter namespace
6. Uncheck Ingest immediately
7. Click "Batch Ingest" (the server attempts to add the temporary name to the database again)
8. Get PDOException: Integrity constraint violation...

I found that this error is also repeatable by adding a csv file, clicking "Start upload" and switching from one template to another

### Proposed solution
Do not let islandora_plupload touch the csv file upload element