### PR TITLE
Prevent an array with a single empty string when submitted through th…

### DIFF
--- a/src/Form/Admin.php
+++ b/src/Form/Admin.php
@@ -86,7 +86,7 @@ class Admin extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $config = $this->config('islandora_spreadsheet_ingest.settings');
-    $whitelist = explode(',', $form_state->getValue('paths'));
+    $whitelist = array_filter(explode(',', $form_state->getValue('paths')));
     $config->set('binary_directory_whitelist', $whitelist);
     $config->set('schemes', array_filter($form_state->getValue('schemes')));
     $config->save();


### PR DESCRIPTION
…e UI.

```php
explode(',', "");
# Yields [ "" ]
array_filter(explode(',', ""));
# Yields []
```

Other places in code assume actual values and iterates over them.