### PR TITLE
SUP-6694: Move migration saving outside of derivation loop.

### DIFF
--- a/src/MigrationDeriver.php
+++ b/src/MigrationDeriver.php
@@ -283,6 +283,8 @@ class MigrationDeriver implements MigrationDeriverInterface {
 
     assert($this->entityTypeManager->getStorage('migration_group')->load($mg_name));
 
+    $migrations = [];
+
     foreach ($request->getMappings() as $name => $info) {
       $original_migration = $this->migrationPluginManager->createInstance($info['original_migration_id']);
       assert($original_migration instanceof MigrationInterface);
@@ -321,10 +323,13 @@ class MigrationDeriver implements MigrationDeriverInterface {
         'migration_tags' => $original_migration->getMigrationTags(),
       ];
 
-      $migration = $this->migrationStorage->load($derived_name) ?? $this->migrationStorage->create();
+      $migrations[] = $migration = $this->migrationStorage->load($derived_name) ?? $this->migrationStorage->create();
       foreach ($info as $key => $value) {
         $migration->set($key, $value);
       }
+    }
+
+    foreach ($migrations as $migration) {
       $migration->save();
     }
 


### PR DESCRIPTION
Having it in the derivation loop was constantly causing `hook_migration_plugins_alter()` to fire.