### PR TITLE
remove rollback feature for now

### DIFF
--- a/src/Form/Ingest/Review.php
+++ b/src/Form/Ingest/Review.php
@@ -6,7 +6,6 @@ use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\dgi_migrate\MigrateBatchExecutable;
-use Drupal\islandora_spreadsheet_ingest\Util\MigrationRollbackBatch;
 use Drupal\migrate\MigrateMessage;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate_tools\MigrateExecutable;

--- a/src/Form/Ingest/Review.php
+++ b/src/Form/Ingest/Review.php
@@ -193,14 +193,6 @@ class Review extends EntityForm {
         'label' => $this->t('Immediate'),
         'callable' => [$this, 'submitProcessImmediate'],
       ],
-      'full_rollback_migration_group' => [
-        'label' => $this->t('Fully Rollback Migration Group'),
-        'callable' => [$this, 'submitProcessRollbackMigrationGroup'],
-      ],
-      'failed_rollback_migration_group' => [
-        'label' => $this->t('Rollback Failed and Ignored Items in Migration Group'),
-        'callable' => [$this, 'submitProcessRollbackFailedMigrationGroup'],
-      ],
     ];
   }
 
@@ -255,82 +247,6 @@ class Review extends EntityForm {
         'backtrace' => $e->getTraceAsString(),
       ]);
       $this->messenger->addError($this->t('Failed to enqueue batch.'));
-    }
-  }
-
-  /**
-   * Callback for the "full_rollback_migration_group" method.
-   */
-  protected function submitProcessRollbackMigrationGroup(array &$form, FormStateInterface $form_state): void {
-    try {
-      $migrations = $this->migrationPluginManager->createInstancesByTag($this->migrationGroupDeriver->deriveTag($this->entity));
-
-      $migrations = array_reverse($migrations);
-
-      $batch = [
-        'operations' => [],
-      ];
-
-      $messenger = new MigrateMessage();
-
-      foreach ($migrations as $migration) {
-        $executable = new MigrationRollbackBatch($migration, $messenger, [
-          'limit' => 0,
-          'update' => 0,
-          'force' => 0,
-          'checkStatus' => FALSE,
-        ]);
-        $batch['operations'][] = [
-          [$this, 'runBatchOp'],
-          [$migration, $executable],
-        ];
-      }
-
-      batch_set($batch);
-    }
-    catch (\Exception $e) {
-      $this->logger('isi.review')->error("Failed to roll back migration: {exc}\n{backtrace}", [
-        'exc' => $e->getMessage(),
-        'backtrace' => $e->getTraceAsString(),
-      ]);
-      $this->messenger->addError($this->t("Failed to rollback migration."));
-    }
-  }
-
-  /**
-   * Callback for the "failed_rollback_migration_group" method.
-   */
-  protected function submitProcessRollbackFailedMigrationGroup(array &$form, FormStateInterface $form_state): void {
-    try {
-      $migrations = $this->migrationPluginManager->createInstancesByTag($this->migrationGroupDeriver->deriveTag($this->entity));
-      $migrations = array_reverse($migrations);
-      $batch = [
-        'operations' => [],
-      ];
-
-      $messenger = new MigrateMessage();
-
-      foreach ($migrations as $migration) {
-        $executable = new MigrationRollbackBatch($migration, $messenger, [
-          'limit' => 0,
-          'update' => 0,
-          'force' => 0,
-          'checkStatus' => TRUE,
-        ]);
-        $batch['operations'][] = [
-          [$this, 'runBatchOp'],
-          [$migration, $executable],
-        ];
-      }
-
-      batch_set($batch);
-    }
-    catch (\Exception $e) {
-      $this->logger('isi.review')->error("Failed to roll back migration: {exc}\n{backtrace}", [
-        'exc' => $e->getMessage(),
-        'backtrace' => $e->getTraceAsString(),
-      ]);
-      $this->messenger->addError($this->t("Failed to rollback migration."));
     }
   }
 


### PR DESCRIPTION
**Removing the risk first, fixing later**

**Steps to reproduce and scope of concern:**

    Run a spreadsheet ingest referencing or creating terms in taxonomies that allow for terms to be created on ingest.

    Run a second spreadsheet ingest that creates more objects referencing the same terms as are referenced/created previously.

    For either of the two ingests, use rollback feature in the UI that was added in https://github.com/discoverygarden/islandora_spreadsheet_ingest/pull/109

    The rollback will delete taxonomy terms still being referenced by existing content, but only for taxonomies that allow for terms to be created on ingest.

**Note about what I mean by taxonomies that allow for terms to be created on ingest:**

This does not appear to affect taxonomies that are more locked down and only allow ingests to reference existing terms. For example, taxonomies like ‘Islandora Models’ or ‘Rights Statements’ need to already have the terms being referenced on ingest in order for the ingest to go through, and the rollback does not delete terms from those taxonomies, only from taxonomies that can have terms created by object ingests (regardless of if the term was created on ingest or not).

Confirmed previously existing rollback functionality is not a concern, so drush command is fine and individual migration rollbacks from migration UI is fine, just the new spreadsheet ingest rollback as noted above is the problem.