### PR TITLE
DDST-748: Adjust config event handler priority

### DIFF
--- a/src/EventSubscriber/ConfigTransformationEventSubscriber.php
+++ b/src/EventSubscriber/ConfigTransformationEventSubscriber.php
@@ -17,6 +17,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class ConfigTransformationEventSubscriber implements EventSubscriberInterface, ContainerInjectionInterface {
 
+  const PRIORITY = 250;
+  
   /**
    * Constructor.
    */
@@ -40,8 +42,8 @@ class ConfigTransformationEventSubscriber implements EventSubscriberInterface, C
    */
   public static function getSubscribedEvents() : array {
     return [
-      ConfigEvents::STORAGE_TRANSFORM_EXPORT => 'onExportTransform',
-      ConfigEvents::STORAGE_TRANSFORM_IMPORT => 'onImportTransform',
+      ConfigEvents::STORAGE_TRANSFORM_EXPORT => [['onExportTransform', static::PRIORITY]],
+      ConfigEvents::STORAGE_TRANSFORM_IMPORT => [['onImportTransform', -static::PRIORITY]],
     ];
   }
 

--- a/src/EventSubscriber/ConfigTransformationEventSubscriber.php
+++ b/src/EventSubscriber/ConfigTransformationEventSubscriber.php
@@ -18,7 +18,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class ConfigTransformationEventSubscriber implements EventSubscriberInterface, ContainerInjectionInterface {
 
   const PRIORITY = 250;
-  
+
   /**
    * Constructor.
    */

--- a/src/Plugin/migrate/source/Spreadsheet.php
+++ b/src/Plugin/migrate/source/Spreadsheet.php
@@ -101,7 +101,7 @@ class Spreadsheet extends SourcePluginBase implements ConfigurableInterface, Con
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration = NULL): self {
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, ?MigrationInterface $migration = NULL): self {
     return new static(
       $configuration,
       $plugin_id,


### PR DESCRIPTION
Needs to be prioritized above any split attempting to export the given config entities. At present, we have wild-card splits at `125`. Let's slap 250 in, for fun?