### PR TITLE
DGI9-637: Exit when an exception is encountered when enqueueing items for the batch.

### DIFF
--- a/src/Form/Ingest/Review.php
+++ b/src/Form/Ingest/Review.php
@@ -161,7 +161,12 @@ class Review extends EntityForm {
         }
       }
       catch (\Exception $ex) {
-        $e->finishBatch(FALSE, [], [], NULL);
+        $e->finishBatch(FALSE, $context['results'], [], NULL);
+        $this->messenger()->addWarning($this->t('Migration (@migration) failed to start with exception: @exception_message', [
+          '@migration' => $migration->id(),
+          '@exception_message' => $ex->getMessage(),
+        ]));
+        return;
       }
       $sandbox['prepped'] = TRUE;
     }


### PR DESCRIPTION
Continuing would attempt to reference properties that are only set during the initialization (such as `$context['sandbox']['total']`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for batch operations. When batch preparation encounters issues, the system now emits detailed warning messages with migration and exception information, while better preserving partial results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->