### PR TITLE
fix: check subprocess exit code in deferred-ingest command

### DIFF
--- a/src/Commands/DeferredIngestCommand.php
+++ b/src/Commands/DeferredIngestCommand.php
@@ -59,6 +59,7 @@ class DeferredIngestCommand extends DrushCommands implements SiteAliasManagerAwa
       $this->logger()->debug('Acquired lock; processing.');
       // Acquired lock, process.
       $request_storage = $this->entityTypeManager->getStorage('isi_request');
+      $failed = FALSE;
       while ($item = $this->queue->claimItem()) {
         // We only care that we made an attempt, so drop the item from the
         // queue.
@@ -95,6 +96,14 @@ class DeferredIngestCommand extends DrushCommands implements SiteAliasManagerAwa
             fwrite(STDOUT, $buffer);
           }
         });
+
+        if (!$process->isSuccessful()) {
+          $this->logger()->error('Subprocess failed for request {id} with exit code {code}.', [
+            'id' => $item->data,
+            'code' => $process->getExitCode(),
+          ]);
+          $failed = TRUE;
+        }
       }
 
       $this->logger()->debug('Processing complete; dropping lock.');
@@ -109,6 +118,10 @@ class DeferredIngestCommand extends DrushCommands implements SiteAliasManagerAwa
       $this->logger()->info('Could not acquire lock; aborting.');
     }
     fclose($lock_pointer);
+
+    if ($failed) {
+      throw new \Exception('One or more deferred ingest subprocesses failed; see log output above.');
+    }
   }
 
 }

--- a/src/Commands/DeferredIngestCommand.php
+++ b/src/Commands/DeferredIngestCommand.php
@@ -55,11 +55,11 @@ class DeferredIngestCommand extends DrushCommands implements SiteAliasManagerAwa
   public function deferredIngest() {
     $lock_path = 'temporary://isi_deferred_lock';
     $lock_pointer = fopen($lock_path, 'w+');
+    $failed = FALSE;
     if (flock($lock_pointer, LOCK_EX | LOCK_NB)) {
       $this->logger()->debug('Acquired lock; processing.');
       // Acquired lock, process.
       $request_storage = $this->entityTypeManager->getStorage('isi_request');
-      $failed = FALSE;
       while ($item = $this->queue->claimItem()) {
         // We only care that we made an attempt, so drop the item from the
         // queue.


### PR DESCRIPTION
## Summary
- `deferredIngest()` spawns a `migrate:batch-import` subprocess per queue item but never checked the exit code after `$process->run()`
- OOM kills (exit 137) and other subprocess failures were silently swallowed, causing the drush command to exit 0 and the Kubernetes job to report Complete despite failed ingests
- Now logs an error for each failed subprocess and throws after all items are processed (after the lock is released), propagating a non-zero exit to the job

## Test plan
- [ ] Trigger a deferred ingest where a subprocess fails (e.g. low memory) and confirm the job now shows Failed rather than Complete
- [ ] Confirm successful ingests still report Complete
- [ ] Confirm the lock is always released even when subprocesses fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deferred data ingestion now detects when subprocess import tasks fail and surfaces those failures instead of completing silently.
  * Failure details (including request identifiers and subprocess exit codes) are logged, and the command now returns an error when a failure is detected so calling processes are informed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->