### PR TITLE
SEC-2819: Deprecate PHPSpreadsheet things.

### DIFF
--- a/src/Form/Admin.php
+++ b/src/Form/Admin.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class Admin extends ConfigFormBase {
 
   /**
-   * Drupal's stream wrapper manager service..
+   * Drupal's stream wrapper manager service.
    *
    * @var \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface
    */

--- a/src/Spreadsheet/ChunkReadFilter.php
+++ b/src/Spreadsheet/ChunkReadFilter.php
@@ -6,6 +6,11 @@ use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
 
 /**
  * Filter adapted directly from PhpSpreadsheet's documentation.
+ *
+ * phpcs:disable Drupal.Semantics.FunctionTriggerError.TriggerErrorTextLayoutRelaxed,Drupal.Commenting.Deprecated.DeprecatedVersionFormat,Drupal.Commenting.Deprecated.DeprecatedWrongSeeUrlFormat
+ *
+ * @deprecated in 3.11.x and is removed from 4.x. Use openspout instead.
+ * @see https://github.com/discoverygarden/islandora_spreadsheet_ingest/issues/129
  */
 class ChunkReadFilter implements IReadFilter {
 
@@ -27,6 +32,7 @@ class ChunkReadFilter implements IReadFilter {
    * Constructor.
    */
   public function __construct($startRow = 0, $chunkSize = 0) {
+    @trigger_error('Deprecated in 3.11.x for removal in 4.x; rework to use another library, such as OpenSpout. See https://github.com/discoverygarden/islandora_spreadsheet_ingest/issues/129', E_USER_DEPRECATED);
     $this->setRows($startRow, $chunkSize);
   }
 

--- a/src/Spreadsheet/SelfDestructingFile.php
+++ b/src/Spreadsheet/SelfDestructingFile.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\islandora_spreadsheet_ingest\src\Spreadsheet;
+namespace Drupal\islandora_spreadsheet_ingest\Spreadsheet;
 
 /**
  * File that deletes itself when garbage collected.

--- a/src/Spreadsheet/SelfDestructingFile.php
+++ b/src/Spreadsheet/SelfDestructingFile.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\islandora_spreadsheet_ingest\src\Spreadsheet;
+
+/**
+ * File that deletes itself when garbage collected.
+ *
+ * @internal
+ */
+class SelfDestructingFile {
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    protected string $filename,
+  ) {}
+
+  /**
+   * Destructor.
+   */
+  public function __destruct() {
+    unlink($this->filename);
+  }
+
+}

--- a/src/Spreadsheet/SpreadsheetService.php
+++ b/src/Spreadsheet/SpreadsheetService.php
@@ -4,7 +4,6 @@ namespace Drupal\islandora_spreadsheet_ingest\Spreadsheet;
 
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\file\FileInterface;
-use Drupal\islandora_spreadsheet_ingest\src\Spreadsheet\SelfDestructingFile;
 use OpenSpout\Common\Exception\IOException;
 use OpenSpout\Reader\CSV\Reader as CSVReader;
 use OpenSpout\Reader\ODS\Reader as ODSReader;

--- a/src/Spreadsheet/SpreadsheetService.php
+++ b/src/Spreadsheet/SpreadsheetService.php
@@ -4,26 +4,44 @@ namespace Drupal\islandora_spreadsheet_ingest\Spreadsheet;
 
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\file\FileInterface;
-use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use Drupal\islandora_spreadsheet_ingest\src\Spreadsheet\SelfDestructingFile;
+use OpenSpout\Common\Exception\IOException;
+use OpenSpout\Reader\CSV\Reader as CSVReader;
+use OpenSpout\Reader\ODS\Reader as ODSReader;
+use OpenSpout\Reader\ReaderInterface;
+use OpenSpout\Reader\SheetInterface;
+use OpenSpout\Reader\XLSX\Reader as XLSXReader;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 /**
  * Spreadsheet service.
+ *
+ * phpcs:disable Drupal.Semantics.FunctionTriggerError.TriggerErrorTextLayoutRelaxed
  */
 class SpreadsheetService implements SpreadsheetServiceInterface {
 
   /**
-   * The file system service.
+   * Allow associating other resources to the lifecycle of readers.
    *
-   * @var \Drupal\Core\File\FileSystemInterface
+   * @var \WeakMap
    */
-  protected $fileSystem;
+  protected \WeakMap $readers;
+
+  /**
+   * Allow associating other resources to the lifecycle of worksheets.
+   *
+   * @var \WeakMap
+   */
+  protected \WeakMap $worksheets;
 
   /**
    * Constructor.
    */
-  public function __construct(FileSystemInterface $file_system) {
-    $this->fileSystem = $file_system;
+  public function __construct(
+    protected FileSystemInterface $fileSystem,
+  ) {
+    $this->readers = new \WeakMap();
+    $this->worksheets = new \WeakMap();
   }
 
   /**
@@ -52,6 +70,7 @@ class SpreadsheetService implements SpreadsheetServiceInterface {
    * {@inheritdoc}
    */
   public function read(FileInterface $file) {
+    @trigger_error('Deprecated in 3.11.x for removal in 4.x; rework to use another library, such as OpenSpout. See https://github.com/discoverygarden/islandora_spreadsheet_ingest/issues/129', E_USER_DEPRECATED);
     $reader = $this->getReader($file);
     return $reader->load($this->getFilePath($file));
   }
@@ -60,6 +79,7 @@ class SpreadsheetService implements SpreadsheetServiceInterface {
    * {@inheritdoc}
    */
   public function getReader(FileInterface $file) {
+    @trigger_error('Deprecated in 3.11.x for removal in 4.x; rework to use another library, such as OpenSpout. See https://github.com/discoverygarden/islandora_spreadsheet_ingest/issues/129', E_USER_DEPRECATED);
     $reader = IOFactory::createReaderForFile($this->getFilePath($file));
     $reader->setReadDataOnly(TRUE);
 
@@ -67,49 +87,134 @@ class SpreadsheetService implements SpreadsheetServiceInterface {
   }
 
   /**
-   * {@inheritdoc}
+   * Get reader for the given file.
+   *
+   * @param \Drupal\file\FileInterface $file
+   *   The file for which to get a reader.
+   *
+   * @return \OpenSpout\Reader\ReaderInterface
+   *   Reader for the file.
+   *
+   * @throws \OpenSpout\Common\Exception\IOException
    */
-  public function getHeader(FileInterface $file, $sheet = NULL, $row = 0) {
-    $reader = $this->getReader($file);
+  private function getSpoutReader(FileInterface $file) : ReaderInterface {
+    $uri = $file->getFileUri();
+    $realpath = $this->fileSystem->realpath($uri);
+    $extension = pathinfo($uri, PATHINFO_EXTENSION);
+    /** @var \OpenSpout\Reader\ReaderInterface $reader_class */
+    $reader_class = match(strtolower($extension)) {
+      'csv' => CSVReader::class,
+      'ods' => ODSReader::class,
+      'xlsx' => XLSXReader::class,
+    };
+    $reader = new $reader_class();
+    $this->readers[$reader] = [];
 
-    if ($sheet) {
-      $reader->setLoadSheetsOnly($sheet);
+    if ($realpath !== FALSE) {
+      $reader->open($realpath);
     }
-    $reader->setReadFilter(new ChunkReadFilter($row, $row + 1));
-    $loaded = $reader->load($this->getFilePath($file));
-
-    foreach ($loaded->getActiveSheet()->getRowIterator() as $row) {
-      $cell_iterator = $row->getCellIterator();
-      $cell_iterator->setIterateOnlyExistingCells(FALSE);
-
-      return array_map([static::class, 'mapCellToValue'], iterator_to_array($cell_iterator));
+    else {
+      try {
+        // Real-path of stream wrappers does not quite make sense, so allow
+        // an opportunity for files from stream wrappers to be processed.
+        $reader->open($uri);
+      }
+      catch (IOException) {
+        // Possibly an exception such as:
+        // "OpenSpout\Common\Exception\IOException: Could not open
+        // {scheme}://{filename}.ods for reading! Stream wrapper used is not
+        // supported for this type of file."
+        // So let's try to spool to a temp file to remove the stream wrapper
+        // from the equation.
+        $spooled = $this->fileSystem->copy($uri, sys_get_temp_dir());
+        $spool_file = $this->fileSystem->realpath($spooled);
+        $this->readers[$reader][] = new SelfDestructingFile($spool_file);
+        $reader->open($spool_file);
+      }
     }
 
-    throw new Exception('Failed to read header.');
+    return $reader;
   }
 
   /**
-   * Get the value of a cell.
+   * Helper; get given worksheet with (Open)Spout.
    *
-   * @param \PhpOffice\PhpSpreadsheet\Cell\Cell $cell
-   *   The cell of which to get the value.
+   * @param \Drupal\file\FileInterface $file
+   *   The file of which to obtain a worksheet.
+   * @param string|null $sheet_name
+   *   The name of the worksheet. Note that not all formats (such as CSV) deal
+   *   with named worksheets.
    *
-   * @return mixed
-   *   The value of the cell.
+   * @return \OpenSpout\Reader\SheetInterface
+   *   The requested sheet.
+   *
+   * @throws \OpenSpout\Common\Exception\IOException
+   * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
    */
-  protected static function mapCellToValue(Cell $cell) {
-    return $cell->getValue();
+  private function getSpoutWorksheet(FileInterface $file, ?string $sheet_name = NULL) : SheetInterface {
+    $reader = $this->getSpoutReader($file);
+
+    if ($reader instanceof CSVReader) {
+      foreach ($reader->getSheetIterator() as $sheet) {
+        $this->worksheets[$sheet] = [$reader];
+        return $sheet;
+      }
+    }
+
+    foreach ($reader->getSheetIterator() as $sheet) {
+      if ($sheet->getName() === $sheet_name) {
+        $this->worksheets[$sheet] = [$reader];
+        return $sheet;
+      }
+    }
+
+    throw new \OutOfBoundsException("Failed to find worksheet of the name '$sheet_name'.");
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getHeader(FileInterface $file, $sheet = NULL, $row = 0) {
+    foreach ($this->getSpoutWorksheet($file, $sheet)->getRowIterator() as $index => $spout_row) {
+      if ($index === $row) {
+        return $spout_row->toArray();
+      }
+    }
+
+    throw new \Exception('Failed to read header.');
   }
 
   /**
    * {@inheritdoc}
    */
   public function listWorksheets(FileInterface $file) {
-    $reader = $this->getReader($file);
-    $lister = [$reader, 'listWorksheetNames'];
-    if (is_callable($lister)) {
-      return call_user_func($lister, $this->getFilePath($file));
+    $reader = $this->getSpoutReader($file);
+
+    return match(TRUE) {
+      $reader instanceof CSVReader => NULL,
+      default => $this->listSpoutSheets($reader),
+    };
+  }
+
+  /**
+   * Helper; get the listing of sheets using (Open)Spout.
+   *
+   * @param \OpenSpout\Reader\ReaderInterface $reader
+   *   The reader to use to list the sheets.
+   *
+   * @return string[]
+   *   The list of sheets.
+   *
+   * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+   */
+  private function listSpoutSheets(ReaderInterface $reader) : array {
+    $sheet_names = [];
+
+    foreach ($reader->getSheetIterator() as $sheet) {
+      $sheet_names[] = $sheet->getName();
     }
+
+    return $sheet_names;
   }
 
 }

--- a/src/Spreadsheet/SpreadsheetServiceInterface.php
+++ b/src/Spreadsheet/SpreadsheetServiceInterface.php
@@ -6,6 +6,8 @@ use Drupal\file\FileInterface;
 
 /**
  * Spreadsheet service interface.
+ *
+ * phpcs:disable Drupal.Commenting.Deprecated.DeprecatedVersionFormat,Drupal.Commenting.Deprecated.DeprecatedWrongSeeUrlFormat
  */
 interface SpreadsheetServiceInterface {
 
@@ -17,6 +19,9 @@ interface SpreadsheetServiceInterface {
    *
    * @return \PhpOffice\PhpSpreadsheet\Spreadsheet
    *   A spreadsheet object representing the given file.
+   *
+   * @deprecated in 3.11.x and is removed from 4.x. Use openspout instead.
+   * @see https://github.com/discoverygarden/islandora_spreadsheet_ingest/issues/129
    */
   public function read(FileInterface $file);
 
@@ -28,6 +33,9 @@ interface SpreadsheetServiceInterface {
    *
    * @return \PhpOffice\PhpSpreadsheet\Reader\IReader
    *   An IReader instance with which the given file might be read.
+   *
+   * @deprecated in 3.11.x and is removed from 4.x. Use openspout instead.
+   * @see https://github.com/discoverygarden/islandora_spreadsheet_ingest/issues/129
    */
   public function getReader(FileInterface $file);
 


### PR DESCRIPTION
Move all processing except that dealing with PHPSpreadsheet explicitly over to use (Open)Spout.

Part of #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecated Features**
  * Multiple spreadsheet processing components have been marked for deprecation, with planned removal in upcoming releases.
  * Users are advised to migrate to the OpenSpout library as an alternative solution.
  * Associated spreadsheet filtering utility is deprecated.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/discoverygarden/islandora_spreadsheet_ingest/pull/130)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->