### PR TITLE
Take a shot at fixing GUI rollback.

### DIFF
--- a/src/Form/Ingest/Review.php
+++ b/src/Form/Ingest/Review.php
@@ -158,6 +158,13 @@ class Review extends EntityForm {
           // Method was introduced in dgi_migrate:3.16, the later use of
           // $sandbox['total'] would have been broken since v3.
           $sandbox['total'] = $e->getQueueSize();
+          if ($sandbox['total'] === 0) {
+            $context['message'] = $this->t('Queue empty.');
+            $context['finished'] = 1;
+            $context['results']['status'] = MigrationInterface::RESULT_COMPLETED;
+            $e->finishBatch(TRUE, $context['results'], [], NULL);
+            return;
+          }
         }
       }
       catch (\Exception $ex) {

--- a/src/Util/MigrationRollbackBatch.php
+++ b/src/Util/MigrationRollbackBatch.php
@@ -131,7 +131,7 @@ class MigrationRollbackBatch extends MigrateBatchExecutable {
     $queue = $this->getQueue();
 
     if (!isset($sandbox['total'])) {
-      $sandbox['total'] = $queue->numberOfItems();
+      $sandbox['total'] = (int) $queue->numberOfItems();
       if ($sandbox['total'] === 0) {
         $context['message'] = $this->t('Queue empty.');
         $context['finished'] = 1;

--- a/src/Util/MigrationRollbackBatch.php
+++ b/src/Util/MigrationRollbackBatch.php
@@ -3,8 +3,8 @@
 namespace Drupal\islandora_spreadsheet_ingest\Util;
 
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
-use Drupal\Core\Queue\QueueInterface;
 use Drupal\dgi_migrate\MigrateBatchException;
+use Drupal\dgi_migrate\MigrateBatchExecutable;
 use Drupal\dgi_migrate\StatusFilter;
 use Drupal\migrate\Event\MigrateEvents;
 use Drupal\migrate\Event\MigrateRollbackEvent;
@@ -12,24 +12,16 @@ use Drupal\migrate\Event\MigrateRowDeleteEvent;
 use Drupal\migrate\MigrateMessageInterface;
 use Drupal\migrate\Plugin\MigrateIdMapInterface;
 use Drupal\migrate\Plugin\MigrationInterface;
-use Drupal\migrate_tools\MigrateExecutable;
 
 /**
  * Class responsible for rolling back a migration in batches.
  */
-class MigrationRollbackBatch extends MigrateExecutable {
+class MigrationRollbackBatch extends MigrateBatchExecutable {
 
   use DependencySerializationTrait {
     __sleep as traitSleep;
     __wakeup as traitWakeup;
   }
-
-  /**
-   * Stores the migration rows.
-   *
-   * @var \Drupal\Core\Queue\QueueInterface
-   */
-  protected QueueInterface $queue;
 
   /**
    * Flag if we should exclusively consider failed and ignored rows to rollback.
@@ -91,7 +83,7 @@ class MigrationRollbackBatch extends MigrateExecutable {
    *   One of the MigrationInterface::RESULT_* constants representing the state
    *   of queueing.
    */
-  private function enqueue(): int {
+  protected function enqueue(): int {
     // Only begin the import operation if the migration is currently idle.
     if ($this->migration->getStatus() !== MigrationInterface::STATUS_IDLE) {
       $this->message->display($this->t('Migration @id is busy with another operation: @status',
@@ -293,27 +285,10 @@ class MigrationRollbackBatch extends MigrateExecutable {
   }
 
   /**
-   * Helper; build out the name of the queue.
-   *
-   * @return string
-   *   The name of the queue.
+   * {@inheritDoc}
    */
   public function getQueueName() : string {
     return "dgi_migrate__rollback_batch_queue__{$this->migration->id()}";
-  }
-
-  /**
-   * Lazy-load the queue.
-   *
-   * @return \Drupal\Core\Queue\QueueInterface
-   *   The queue implementation to use.
-   */
-  protected function getQueue() : QueueInterface {
-    if (!isset($this->queue)) {
-      $this->queue = \Drupal::queue($this->getQueueName(), TRUE);
-    }
-
-    return $this->queue;
   }
 
 }

--- a/src/Util/MigrationRollbackBatch.php
+++ b/src/Util/MigrationRollbackBatch.php
@@ -3,6 +3,7 @@
 namespace Drupal\islandora_spreadsheet_ingest\Util;
 
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\dgi_migrate\MigrateBatchException;
 use Drupal\dgi_migrate\MigrateBatchExecutable;
 use Drupal\dgi_migrate\StatusFilter;
@@ -17,6 +18,8 @@ use Drupal\migrate\Plugin\MigrationInterface;
  * Class responsible for rolling back a migration in batches.
  */
 class MigrationRollbackBatch extends MigrateBatchExecutable {
+
+  use MessengerTrait;
 
   use DependencySerializationTrait {
     __sleep as traitSleep;
@@ -273,10 +276,10 @@ class MigrationRollbackBatch extends MigrateBatchExecutable {
    */
   public function finishBatch($success, $results, $ops, $interval): void {
     if (isset($results['errors']) && !empty($results['errors'])) {
-      $this->messenger->addError($this->t('Rollback encountered errors.'));
+      $this->messenger()->addError($this->t('Rollback encountered errors.'));
       foreach ($results['errors'] as $e) {
         $error_message = is_object($e) ? json_encode($e) : (string) $e;
-        $this->messenger->addError($this->t('Migration group rollback failed with exception: @e', ['@e' => $error_message]));
+        $this->messenger()->addError($this->t('Migration group rollback failed with exception: @e', ['@e' => $error_message]));
       }
     }
 


### PR DESCRIPTION
The removal of `::checkStatus()` in D11.3 is making mess. We have already dealt with such over in https://github.com/discoverygarden/dgi_migrate/pull/180/changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated migration rollback batch execution to improve queue handling and message/error reporting during batch operations.
* **Bug Fixes**
  * Batch jobs now gracefully complete when the queue reports zero items, avoiding unnecessary further processing and ensuring results are marked completed.
* **Maintainability**
  * Refined internal method behavior and documentation to improve consistency and clarity during rollback batch runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->